### PR TITLE
ownerDaiFunds & Public Key BroadCast function Issue Resolved

### DIFF
--- a/packages/buidler/contracts/EPNSCore.sol
+++ b/packages/buidler/contracts/EPNSCore.sol
@@ -944,7 +944,7 @@ contract EPNSCore is Initializable, ReentrancyGuard  {
         IERC20(daiAddress).safeTransferFrom(msg.sender, address(this), DELEGATED_CONTRACT_FEES);
 
         // Add it to owner kitty
-        ownerDaiFunds.add(DELEGATED_CONTRACT_FEES);
+        ownerDaiFunds = ownerDaiFunds.add(DELEGATED_CONTRACT_FEES);
     }
 
     /// @dev deposit funds to pool

--- a/packages/buidler/contracts/EPNSCore.sol
+++ b/packages/buidler/contracts/EPNSCore.sol
@@ -445,7 +445,7 @@ contract EPNSCore is Initializable, ReentrancyGuard  {
         // Will save gas as it prevents calldata to be copied unless need be
         if (users[_user].publicKeyRegistered == false) {
         // broadcast it
-        _broadcastPublicKey(msg.sender, _publicKey);
+        _broadcastPublicKey(_user, _publicKey);
         }
 
         // Call actual subscribe

--- a/packages/buidler/contracts/EPNSCoreV2.sol
+++ b/packages/buidler/contracts/EPNSCoreV2.sol
@@ -944,7 +944,7 @@ contract EPNSCore is Initializable, ReentrancyGuard  {
         IERC20(daiAddress).safeTransferFrom(msg.sender, address(this), DELEGATED_CONTRACT_FEES);
 
         // Add it to owner kitty
-        ownerDaiFunds.add(DELEGATED_CONTRACT_FEES);
+        ownerDaiFunds = ownerDaiFunds.add(DELEGATED_CONTRACT_FEES);
     }
 
     /// @dev deposit funds to pool

--- a/packages/buidler/contracts/EPNSCoreV2.sol
+++ b/packages/buidler/contracts/EPNSCoreV2.sol
@@ -371,7 +371,7 @@ contract EPNSCore is Initializable, ReentrancyGuard  {
 
     /// @dev Create channel with fees and public key
     function createChannelWithFeesAndPublicKey(ChannelType _channelType, bytes calldata _identity, bytes calldata _publickey)
-        external onlyUserWithNoChannel onlyUserAllowedChannelType(_channelType) {
+        external onlyUserWithNoChannel onlyUserAllowedChannelType(_channelType) onlyChannelizationWhitelist(msg.sender) {
         // Save gas, Emit the event out
         emit AddChannel(msg.sender, _channelType, _identity);
 
@@ -389,7 +389,7 @@ contract EPNSCore is Initializable, ReentrancyGuard  {
 
     /// @dev Create channel with fees
     function createChannelWithFees(ChannelType _channelType, bytes calldata _identity)
-      external onlyUserWithNoChannel onlyUserAllowedChannelType(_channelType) {
+      external onlyUserWithNoChannel onlyUserAllowedChannelType(_channelType) onlyChannelizationWhitelist(msg.sender) {
         // Save gas, Emit the event out
         emit AddChannel(msg.sender, _channelType, _identity);
 
@@ -445,7 +445,7 @@ contract EPNSCore is Initializable, ReentrancyGuard  {
         // Will save gas as it prevents calldata to be copied unless need be
         if (users[_user].publicKeyRegistered == false) {
         // broadcast it
-        _broadcastPublicKey(_user, _publicKey);
+        _broadcastPublicKey(msg.sender, _publicKey);
         }
 
         // Call actual subscribe
@@ -944,7 +944,7 @@ contract EPNSCore is Initializable, ReentrancyGuard  {
         IERC20(daiAddress).safeTransferFrom(msg.sender, address(this), DELEGATED_CONTRACT_FEES);
 
         // Add it to owner kitty
-        ownerDaiFunds = ownerDaiFunds.add(DELEGATED_CONTRACT_FEES);
+        ownerDaiFunds.add(DELEGATED_CONTRACT_FEES);
     }
 
     /// @dev deposit funds to pool
@@ -963,7 +963,7 @@ contract EPNSCore is Initializable, ReentrancyGuard  {
     }
 
         /// @dev withdraw funds from pool
-    function _withdrawFundsFromPool(uint ratio) private nonReentrant {
+    function _withdrawFundsFromPool(uint ratio) private {
         uint totalBalanceWithProfit = IERC20(aDaiAddress).balanceOf(address(this));
 
         // // Random for testing

--- a/packages/buidler/contracts/EPNSCoreV2.sol
+++ b/packages/buidler/contracts/EPNSCoreV2.sol
@@ -445,7 +445,7 @@ contract EPNSCore is Initializable, ReentrancyGuard  {
         // Will save gas as it prevents calldata to be copied unless need be
         if (users[_user].publicKeyRegistered == false) {
         // broadcast it
-        _broadcastPublicKey(msg.sender, _publicKey);
+        _broadcastPublicKey(_user, _publicKey);
         }
 
         // Call actual subscribe

--- a/packages/buidler/contracts/EPNSCoreV3.sol
+++ b/packages/buidler/contracts/EPNSCoreV3.sol
@@ -935,7 +935,7 @@ contract EPNSCorev3 is Initializable, ReentrancyGuard  {
         IERC20(daiAddress).safeTransferFrom(msg.sender, address(this), DELEGATED_CONTRACT_FEES);
 
         // Add it to owner kitty
-        ownerDaiFunds.add(DELEGATED_CONTRACT_FEES);
+        ownerDaiFunds = ownerDaiFunds.add(DELEGATED_CONTRACT_FEES);
     }
 
     /// @dev deposit funds to pool

--- a/packages/buidler/contracts/EPNSCoreV3.sol
+++ b/packages/buidler/contracts/EPNSCoreV3.sol
@@ -445,7 +445,7 @@ contract EPNSCorev3 is Initializable, ReentrancyGuard  {
         // Will save gas as it prevents calldata to be copied unless need be
         if (users[_user].publicKeyRegistered == false) {
         // broadcast it
-        _broadcastPublicKey(msg.sender, _publicKey);
+        _broadcastPublicKey(_user, _publicKey);
         }
 
         // Call actual subscribe


### PR DESCRIPTION
This PR resolves 2 major issues in the Protocol:

1.The issue with the **_takeDelegationFees()** function where _**DELEGATED_CONTRACT_FEES**_ amount was taken from the Channel Owner but the same was never updated in the **ownerDaiFunds** State Variable.

**Reason:**
The _**ownerDaiFunds** state variable was incremented but never stored in the Contract._
`       ownerDaiFunds.add(DELEGATED_CONTRACT_FEES);
`

**Solution:**
`        ownerDaiFunds = ownerDaiFunds.add(DELEGATED_CONTRACT_FEES);
`

---
2. The 2nd issue involves the broadcasting of the User's Public key in the **subscribeWithPublicKeyDelegated** function. 

**Reason:**
The Channel Owner's address was broadcasted instead of the user's. This is because **msg.sender** was being passed in the _**_broadcastPublicKey**_ internal function instead of the user's address.

` if (users[_user].publicKeyRegistered == false) {
        // broadcast it
        _broadcastPublicKey(msg.sender, _publicKey);
        }
`
**Solution:**

` if (users[_user].publicKeyRegistered == false) {
        // broadcast it
        _broadcastPublicKey(_user, _publicKey);
        }
`


