### PR TITLE
Protocol CleanUp #PR-1st

### DIFF
--- a/packages/buidler/contracts/EPNSCoreV3.sol
+++ b/packages/buidler/contracts/EPNSCoreV3.sol
@@ -202,7 +202,6 @@ contract EPNSCoreV3 is Initializable, ReentrancyGuard  {
     event InterestClaimed(address indexed user, uint indexed amount);
 
     // Withdrawl Related
-    event Donation(address indexed donator, uint amt);
     event Withdrawal(address indexed to, address token, uint amount);
 
     /* ***************
@@ -642,14 +641,6 @@ contract EPNSCoreV3 is Initializable, ReentrancyGuard  {
     /// @dev To fetch user id for a subscriber of a channel
     function getChannelSubscriberUserID(address _channel, uint _subscriberId) external view returns (uint userId) {
         userId = channels[_channel].members[channels[_channel].mapAddressMember[_subscriberId]];
-    }
-
-    /// @dev donate functionality for the smart contract
-    function donate() public payable {
-        require(msg.value >= 0.001 ether, "Minimum Donation amount is 0.001 ether");
-
-        // Emit Event
-        emit Donation(msg.sender, msg.value);
     }
 
     /// @dev to get channel fair share ratio for a given block

--- a/packages/buidler/contracts/EPNSCoreV3.sol
+++ b/packages/buidler/contracts/EPNSCoreV3.sol
@@ -400,11 +400,8 @@ contract EPNSCoreV3 is Initializable, ReentrancyGuard  {
       /// @dev One time, Create Promoter Channel
     function createPromoterChannel() external {
       // EPNS PROMOTER CHANNEL
-      require(users[address(this)].channellized == false, "Contract has Promoter");
-
-      // NEED TO HAVE ALLOWANCE OF MINIMUM DAI
-      IERC20(daiAddress).approve(address(this), ADD_CHANNEL_MIN_POOL_CONTRIBUTION);
-
+      require(!users[address(this)].channellized, "Contract has Promoter");
+      
       // Check the allowance and transfer funds
       IERC20(daiAddress).transferFrom(msg.sender, address(this), ADD_CHANNEL_MIN_POOL_CONTRIBUTION);
 


### PR DESCRIPTION
This is the first PR under the category of Protocol CleanUp process.

The PR includes the following modifications as of now:

1. Comparision to Boolean Constant Fixes
2. CreatePromoter Channel function's APPROVE Issue
_The following Line has been removed from the **createPromoterChannel** Function:_ 
`      IERC20(daiAddress).approve(address(this), ADD_CHANNEL_MIN_POOL_CONTRIBUTION);`
This modification is implemented as the users shall approve the Protocol Address from outside the Contract. And as far as the allowance check is concerned, the **transferFrom** function of ERC20 standard, already implements that check within itself.

3. Removal of **Donation** function